### PR TITLE
Fix ListTemplates api returns AppTemplateName as null

### DIFF
--- a/src/cmd/apps/templates.go
+++ b/src/cmd/apps/templates.go
@@ -1,22 +1,23 @@
 package apps
 
 import (
-	"com.azure.iot/iotcentral/iotcgo/config"
-	"com.azure.iot/iotcentral/iotcgo/util"
 	"context"
 	"fmt"
+	"os"
+
+	"com.azure.iot/iotcentral/iotcgo/config"
+	"com.azure.iot/iotcentral/iotcgo/util"
 	"github.com/Azure/azure-sdk-for-go/services/iotcentral/mgmt/2018-09-01/iotcentral"
 	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 // listTemplatesCmd represents the app templates list command
 var listTemplatesCmd = &cobra.Command{
 	Use:   "listTemplates",
 	Short: "Get the list of all the app templates",
-	Long: `Get the list of all the app templates.`,
+	Long:  `Get the list of all the app templates.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// read the command line parameters
 		subscription, err := cmd.Flags().GetString("subscription")
@@ -76,11 +77,7 @@ func printTemplatesTable(templates []iotcentral.AppTemplate, format string) {
 	t.AppendHeader(table.Row{"#", "ID", "Title", "Description", "Version", "Order", "Template Name"})
 
 	for i, item := range templates {
-		var templateName string = ""
-		if item.AppTemplateName != nil {
-			templateName = *item.AppTemplateName
-		}
-		t.AppendRow([]interface{}{i + 1, *item.ManifestID, *item.Title, *item.Description, *item.ManifestVersion, *item.Order, templateName})
+		t.AppendRow([]interface{}{i + 1, *item.ManifestID, *item.Title, *item.Description, *item.ManifestVersion, *item.Order, *item.Name})
 	}
 	util.RenderTable(t, format, false)
 }

--- a/src/go.mod
+++ b/src/go.mod
@@ -3,7 +3,8 @@ module com.azure.iot/iotcentral/iotcgo
 go 1.15
 
 require (
-	github.com/Azure/azure-sdk-for-go v49.0.0+incompatible
+	github.com/Azure/azure-sdk-for-go v50.0.0+incompatible
+	github.com/Azure/go-autorest/autorest v0.11.15
 	github.com/Azure/go-autorest/autorest/azure/auth v0.5.3
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/Azure/go-autorest/autorest/validation v0.3.0 // indirect

--- a/src/go.sum
+++ b/src/go.sum
@@ -13,10 +13,14 @@ cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiy
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
 github.com/Azure/azure-sdk-for-go v49.0.0+incompatible h1:rvYYNgKNBwoxUaBFmd/+TpW3qrd805EHBBvUp5FmFso=
 github.com/Azure/azure-sdk-for-go v49.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v50.0.0+incompatible h1:kFIPXbg+knN0rsmsj3jIuoxOYCsevOwvwUgwICmrIwA=
+github.com/Azure/azure-sdk-for-go v50.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/go-autorest v14.2.0+incompatible h1:V5VMDjClD3GiElqLWO7mz2MxNAK/vTfRHdAubSIPRgs=
 github.com/Azure/go-autorest v14.2.0+incompatible/go.mod h1:r+4oMnoxhatjLLJ6zxSWATqVooLgysK6ZNox3g/xq24=
 github.com/Azure/go-autorest/autorest v0.11.9 h1:P0ZF0dEYoUPUVDQo3mA1CvH5b8mKev7DDcmTwauuNME=
 github.com/Azure/go-autorest/autorest v0.11.9/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
+github.com/Azure/go-autorest/autorest v0.11.15 h1:S5SDFpmgoVyvMEOcULyEDlYFrdPmu6Wl0Ic+shkEwzg=
+github.com/Azure/go-autorest/autorest v0.11.15/go.mod h1:eipySxLmqSyC5s5k1CLupqet0PSENBEDP93LQ9a8QYw=
 github.com/Azure/go-autorest/autorest/adal v0.9.5 h1:Y3bBUV4rTuxenJJs41HU3qmqsb+auo+a3Lz+PlJPpL0=
 github.com/Azure/go-autorest/autorest/adal v0.9.5/go.mod h1:B7KF7jKIeC9Mct5spmyCB/A8CG/sEz1vwIRGv/bbw7A=
 github.com/Azure/go-autorest/autorest/azure/auth v0.5.3 h1:lZifaPRAk1bqg5vGqreL6F8uLC5V0fDpY8nFvc3boFc=


### PR DESCRIPTION
* Did go SDK release to fix this issue. Leverage latest go SDK in this PR.
* Azure SDK for GO 50.0.0 requires autorest to be at least [v0.11.15](https://github.com/Azure/azure-sdk-for-go/issues/14141)

Fix in the screenshot:
![image](https://user-images.githubusercontent.com/12833803/108570893-c2f5a600-72c3-11eb-91d3-3b9fedc80fb6.png)